### PR TITLE
fix: use v2 of grpc-gateway

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,8 @@ RUN git clone https://github.com/google/protobuf.git && \
 
 RUN go get google.golang.org/grpc
 
-RUN go get -u github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway
-RUN go get -u github.com/grpc-ecosystem/grpc-gateway/protoc-gen-openapiv2
+RUN go get -u github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway
+RUN go get -u github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2
 RUN go get github.com/golang/protobuf/protoc-gen-go
 
 RUN cp /go/bin/protoc-gen-go /usr/bin/


### PR DESCRIPTION
Switched to v2 as protoc-gen-openapiv2 seems to be not available
in v1: https://github.com/grpc-ecosystem/grpc-gateway/tree/v1

Alternatively we could probably remove downloading of these packages.